### PR TITLE
Dynamic server branding support

### DIFF
--- a/db/caches.php
+++ b/db/caches.php
@@ -28,4 +28,7 @@ $definitions = [
     'discovery' => [
         'mode' => cache_store::MODE_APPLICATION,
     ],
+    'capabilities' => [
+        'mode' => cache_store::MODE_APPLICATION,
+    ],
 ];

--- a/lang/en/collabora.php
+++ b/lang/en/collabora.php
@@ -25,12 +25,15 @@
 defined('MOODLE_INTERNAL') || die();
 
 $string['cachedef_discovery'] = 'Collabora discovery XML file';
+$string['discovery_error_no_caps_url'] = 'The discovery.xml file does not contain the Capabilities URL';
+$string['cachedef_capabilities'] = 'Capabilities file and fields';
 $string['collabora:addinstance'] = 'Add collaborative document to a course';
 $string['collabora:editlocked'] = 'Edit a locked collaborative document';
 $string['collabora:lock'] = 'Lock/unlock a collaborative document';
 $string['collabora:view'] = 'View a collaborative document';
-$string['collaboraurl'] = 'Collabora URL';
-$string['collaboraurlnotset'] = 'Collabora URL is not configured for this site';
+$string['default_server_name'] = 'Collabora Online';
+$string['collaboraurl'] = '{$a} URL';
+$string['collaboraurlnotset'] = '{$a} URL is not configured for this site';
 $string['current'] = 'Current tab';
 $string['defaultdisplay'] = 'Default display';
 $string['defaultdisplaydescription'] = 'Default display description';

--- a/settings.php
+++ b/settings.php
@@ -25,8 +25,35 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
+
+    $productname = '';
+    try {
+        // If we have a URL, fetch the product name from the server.
+        // And if we had it, re-fetch it, in case it's changed.
+        if (get_config('mod_collabora', 'url')) {
+            $collabora = new \mod_collabora\collabora(0, 0, -1, 0);
+            // Remove from the cache to force fetching.
+            $collabora->reset_caches();
+            $productname = $collabora->get_product_name();
+        }
+    } catch (Exception $e) {
+        // For some reason we couldn't discover the server name.
+        // Possibly the server doesn't have the capabilities file.
+        $productname = '';
+    }
+    finally {
+        // Fallback.
+        if (empty($productname)) {
+            $cache = \cache::make('mod_collabora', 'capabilities');
+            if (!$productname = $cache->get('productname')) {
+                // If it's not already cached, default, as we are aren't configured yet.
+                $productname = get_string('default_server_name', 'mod_collabora');
+            }
+        }
+    }
+
     $settings->add(new admin_setting_configtext('mod_collabora/url',
-                                                new lang_string('collaboraurl', 'mod_collabora'), '', '', PARAM_URL));
+                                                new lang_string('collaboraurl', 'mod_collabora', $productname), '', '', PARAM_URL));
 
     $settings->add(new admin_setting_configselect('mod_collabora/defaultformat',
                                                   new lang_string('defaultformat', 'mod_collabora'), '',

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020090100;
+$plugin->version = 2020091200;
 $plugin->requires = 2018051700; // M3.5.
 $plugin->component = 'mod_collabora';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The Online server product name is now
dynamically pulled from the server, once a
valid URL is provided. After the initial
discovery of the server capabilities, the
product-name is cached.

However we allow for changing the server
(or, upon updating the server the product
name may have been changed) by clearing
the cache from the plugin settings page.
Simply loading the settings page will
invalidate the cache, if a URL is already
set and is valid, and will pull the new
name.

The relevant strings displayed in the UI
have been updated to use the product name
provided by the server with proper fallback.