### PR TITLE
mod_collabora: Fix getting groupmode from cm

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -115,7 +115,8 @@ class api {
         // Check the group access.
         $this->isgroupmember = true;
         list($this->course, $this->cm) = get_course_and_cm_from_cmid($this->context->instanceid, 'collabora');
-        if ($this->cm->groupmode == NOGROUPS) {
+        $groupmode = groups_get_activity_groupmode($this->cm);
+        if ($groupmode == NOGROUPS) {
             if ($groupid != 0) {
                 throw new \moodle_exception('invalidgroupid', 'mod_collabora');
             }
@@ -127,7 +128,7 @@ class api {
                 throw new \moodle_exception('invalidgroupid', 'mod_collabora');
             }
             $this->isgroupmember = groups_is_member($groupid, $this->userid);
-            if ($this->cm->groupmode == SEPARATEGROUPS && !$this->isgroupmember) {
+            if ($groupmode == SEPARATEGROUPS && !$this->isgroupmember) {
                 require_capability('moodle/site:accessallgroups', $this->context, $this->userid);
             }
         }


### PR DESCRIPTION
This is a fix mod_collabora
### Description
If you have a course set on `groupmode = SEPARATEGROUPS` and additionally `groupmodeforce = yes`, then you can not edit new created collabora documents.
In `mod_collabora\api::parse_fileid()` the groupmode is checked only by asking the groupmode property from the cm instance `$this->cm->groupmode`. So the setting in the course is falsely ignored.
The effective groupmode should be ask by using the function `groups_get_activity_groupmode()`.

### Test instructions

1. Prepare the course settings: `Group mode: Separate groups`  and `Force group mode: Yes`.
1. Activate the editing mode.
1. Add a new collabora instance with one of the integrated templates (Spreadsheet, Presentation or Wordprocessor).
1. Show this new instance.
1. Without the fix an error occurs and with the fix the document works as expected. 