### PR TITLE
mod_collabora: fix iframe height to show office status bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -44,7 +44,7 @@
 .collabora-frame.embedded {
     position: fixed;
     height: auto;
-    min-height: 100%;
+    min-height: calc(100% - 25px);
 }
 
 /* Some rules for non boost themes like clean */

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020111300;
+$plugin->version = 2020111600;
 $plugin->requires = 2019051100; // M3.7.
 $plugin->component = 'mod_collabora';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v3.10-r1';
+$plugin->release = 'v3.10-r2';


### PR DESCRIPTION
If mod_collabora is called in a new browser tab the status bar at the bottom is not shown.
This fix corrects the height of the iframe, so the status bar is shown.