### PR TITLE
Ensure LastModifiedTime is in UTC

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -232,6 +232,8 @@ class api {
      * Handle checkfileinfo requests.
      */
     private function handle_checkfileinfo() {
+        $tz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
         $file = $this->get_stored_file();
         $ret = (object)[
             'BaseFileName' => clean_filename($file->get_filename()),
@@ -243,6 +245,7 @@ class api {
             'UserCanNotWriteRelative' => true,
             'LastModifiedTime' => date('c', $file->get_timemodified()),
         ];
+        date_default_timezone_set($tz);
         die(json_encode($ret));
     }
 }


### PR DESCRIPTION
Collabora API requires LastModifiedTime in ISO 8601 UTC format ('Y-m-d\TH:i:s.u\Z')
see https://github.com/EGroupware/collabora/blob/06bc8ea996f9c54caa1e5205da7842b5af186c91/src/Wopi/Files.php#L31

fixes #31 

I applied this patch to the MOODLE_39_STABLE branch. When accepted it must be ported to master/MOODLE_311_STABLE.