### PR TITLE
mod_collabora: provide the user pic via WOPI

### DIFF
--- a/classes/api/api.php
+++ b/classes/api/api.php
@@ -162,6 +162,9 @@ class api {
             'UserCanWrite'            => !$this->filesystem->is_readonly(),
             'UserFriendlyName'        => $this->filesystem->get_username(),
             'UserId'                  => $this->filesystem->get_user_identifier(),
+            'UserExtraInfo'           => [
+                'avatar' => $this->filesystem->get_userpicture_url(),
+            ],
         ];
 
         date_default_timezone_set($tz);

--- a/classes/api/base_filesystem.php
+++ b/classes/api/base_filesystem.php
@@ -666,6 +666,18 @@ abstract class base_filesystem {
     }
 
     /**
+     * Get the user picture of who is working on this document.
+     *
+     * @return string
+     */
+    public function get_userpicture_url() {
+        global $PAGE;
+        $userpicture = new \user_picture($this->user);
+        $userpicture->size = 1;
+        return $userpicture->get_url($PAGE)->out(false);
+    }
+
+    /**
      * Unique identifier for the owner of the document.
      *
      * @return string


### PR DESCRIPTION
To reproduce or test:

Open a document more than once (can be the same user or different users). If the users have a user picture set in moodle, it will appear.

![image](https://github.com/user-attachments/assets/941812f0-a3fc-450f-8772-96ba70fbed4b)


 