### PR TITLE
mod_collabora: Fix HTML iframe tag to allow clipboard read / write in Chrome

### DIFF
--- a/templates/iframe.mustache
+++ b/templates/iframe.mustache
@@ -33,7 +33,8 @@
             class="collabora-iframe border w-100 h-100"
             id="collaboraiframe_{{id}}"
             name="collaboraiframe_{{id}}"
-            src="about:blank" allowFullscreen>
+            src="about:blank" allowFullscreen
+            allow="clipboard-read *; clipboard-write *">
         </iframe>
     </div>
     {{> mod_collabora/spinner }}


### PR DESCRIPTION
This pull request is related to issue #55.

**Summary**: with Edge and Chrome browsers (Firefox works correctly), the copy and paste option within the document does not work. Neither Ctrl+C nor Ctrl+V work, nor does the right-click copy and paste option.

**Solution**: according to Collabora’s documentation about integrations (https://sdk.collaboraonline.com/docs/advanced_integration.html#allow-the-clipboard-permission-query), the HTML `<iframe>` tag in Chrome needs to contain the following element:

`<iframe allow="clipboard-read *; clipboard-write *"/>`

So we modified the `<iframe>` tag in the file `/templates/iframe.mustache` (line 32), we added that element and the issue was resolved. Now we can copy and paste with the keyboard or using the buttons in Collabora without any problem in Chrome.

Thanks.